### PR TITLE
Set dropout ratio to zero

### DIFF
--- a/configs/mrt_cross_domain.yaml
+++ b/configs/mrt_cross_domain.yaml
@@ -81,7 +81,7 @@ model:
         # typically ff_size = 4 x hidden_size
         hidden_size: 128
         ff_size: 512
-        dropout: 0.3
+        dropout: 0.0
     decoder:
         type: "transformer"
         num_layers: 6
@@ -93,4 +93,4 @@ model:
         # typically ff_size = 4 x hidden_size
         hidden_size: 128
         ff_size: 512
-        dropout: 0.3
+        dropout: 0.0

--- a/configs/mrt_in_domain.yaml
+++ b/configs/mrt_in_domain.yaml
@@ -81,7 +81,7 @@ model:
         # typically ff_size = 4 x hidden_size
         hidden_size: 256
         ff_size: 1024
-        dropout: 0.3
+        dropout: 0.0
     decoder:
         type: "transformer"
         num_layers: 6
@@ -93,4 +93,4 @@ model:
         # typically ff_size = 4 x hidden_size
         hidden_size: 256
         ff_size: 1024
-        dropout: 0.3
+        dropout: 0.0

--- a/configs/pg_cross_domain.yaml
+++ b/configs/pg_cross_domain.yaml
@@ -79,7 +79,7 @@ model:
         # typically ff_size = 4 x hidden_size
     hidden_size: 128
     ff_size: 512
-    dropout: 0.3
+    dropout: 0.0
   decoder:
     type: "transformer"
     num_layers: 6
@@ -91,4 +91,4 @@ model:
         # typically ff_size = 4 x hidden_size
     hidden_size: 128
     ff_size: 512
-    dropout: 0.3
+    dropout: 0.0

--- a/configs/pg_in_domain.yaml
+++ b/configs/pg_in_domain.yaml
@@ -79,7 +79,7 @@ model:
         # typically ff_size = 4 x hidden_size
     hidden_size: 256
     ff_size: 1024
-    dropout: 0.3
+    dropout: 0.0
   decoder:
     type: "transformer"
     num_layers: 6
@@ -91,4 +91,4 @@ model:
         # typically ff_size = 4 x hidden_size
     hidden_size: 256
     ff_size: 1024
-    dropout: 0.3
+    dropout: 0.0

--- a/configs/sbp_cross_domain.yaml
+++ b/configs/sbp_cross_domain.yaml
@@ -84,7 +84,7 @@ model:
         # typically ff_size = 4 x hidden_size
     hidden_size: 128
     ff_size: 512
-    dropout: 0.3
+    dropout: 0.0
   decoder:
     type: "transformer"
     num_layers: 6
@@ -96,4 +96,4 @@ model:
         # typically ff_size = 4 x hidden_size
     hidden_size: 128
     ff_size: 512
-    dropout: 0.3
+    dropout: 0.0

--- a/configs/sbp_in_domain.yaml
+++ b/configs/sbp_in_domain.yaml
@@ -84,7 +84,7 @@ model:
         # typically ff_size = 4 x hidden_size
     hidden_size: 256
     ff_size: 1024
-    dropout: 0.3
+    dropout: 0.0
   decoder:
     type: "transformer"
     num_layers: 6
@@ -96,4 +96,4 @@ model:
         # typically ff_size = 4 x hidden_size
     hidden_size: 256
     ff_size: 1024
-    dropout: 0.3
+    dropout: 0.0


### PR DESCRIPTION
Dropoutを抜いても特に性能の低下が見受けられなかったため、下記の実験設定においてDropout率を全て0.0に設定します。

- PG, MRT, SBP
- In-domain, Cross-domain

参考: #7 