### PR TITLE
閾値計算部分の改訂

### DIFF
--- a/joeynmt/decoders.py
+++ b/joeynmt/decoders.py
@@ -910,7 +910,7 @@ class TransformerDecoder(Decoder):
         """
         assert trg_mask is not None, "trg_mask required for Transformer"
 
-        # if there are alredy finished seqs, use unfinished seqs only
+        # if there are already finished seqs, use unfinished seqs only
         if not_using_finished := (finished is not None and (fin_size := finished.size(0)) > 0):
             # if all finished, return fixed outputs
             if fin_size == trg_embed.size(0):
@@ -945,7 +945,7 @@ class TransformerDecoder(Decoder):
         x = self.layer_norm(x)
         output = self.output_layer(x)
 
-        # finally, concatenate finished and unfinshed outputs
+        # finally, concatenate finished and unfinished outputs
         if not_using_finished:
             output_finished = output.new_full(
                 (fin_size, 1, output.size(2)),

--- a/joeynmt/model.py
+++ b/joeynmt/model.py
@@ -588,8 +588,10 @@ class Model(nn.Module):
                                  is adopted with probability "(threshold - smoothing_factor)/smoothing_factor"
         :return:
             - threshold_of_all_steps: [torch.tensor(batch=0), ..., torch.tensor(batch=batch_size-1)]
-            - beam_seq_of_all_steps: [beam_seq_of_all_steps[batch=0], ..., beam_seq_of_all_steps[batch=0]]
-            - beam_prob_of_all_steps: [beam_prob_of_all_steps[batch=0], ..., beam_prob_of_all_steps[batch=0]]
+            - beam_seq_of_all_steps: [list(batch=0), ..., list(batch=batch_size-1)]
+            - beam_prob_of_all_steps: [list(batch=0), ..., list(batch=batch_size-1)]
+            Note: Each tensor or list contains information at each step (1~L),
+                  where L is the maximum step size and may vary by batch index.
         """
         # don't use dropouts during beam search
         self.decoder.eval()
@@ -832,7 +834,7 @@ class Model(nn.Module):
         :param n_best: return this many hypotheses, <= beam
         :return:
             - thresholds: torch.tensor (max_output_length),
-            - beam_seq_of_all_steps: [beam_seq_list(step=0), ..., beam_seq_list(step=max_output_length-1)]
+            - beam_seq_of_all_steps: [beam_seq(step=0), ..., beam_seq(step=max_output_length-1)]
         """
         # don't use dropouts during beam search
         self.decoder.eval()

--- a/joeynmt/model.py
+++ b/joeynmt/model.py
@@ -572,7 +572,7 @@ class Model(nn.Module):
     def _compute_threshold_by_vanilla_beam_search(self, beam_size: int,
                                                   encoder_output: Tensor, encoder_hidden: Tensor, src_mask: Tensor,
                                                   temperature: float, alpha: float = 1.0,
-                                                  smoothing_window: float = 0.0) -> (np.array, np.array):
+                                                  max_iteration: int = 10, smoothing_factor: float = 0.8) -> (np.array, np.array):
         """
         Compute thresholds for soft beam policy based on vanilla_beam_search with size k.
 
@@ -582,13 +582,14 @@ class Model(nn.Module):
         :param src_mask:
         :param temperature: softmax temperature
         :param alpha: `alpha` factor for length penalty
-        :param smoothing_window: smoothing window for stochastic sampling
+        :param max_iteration: if the iteration does not end after 'max_iteration' times, the iteration is terminated
+        :param smoothing_factor: If 'smoothing_factor'>0,
+                                 hypotheses with score less than “threshold” but greater than "threshold - smoothing_factor"
+                                 is adopted with probability "(threshold - smoothing_factor)/smoothing_factor"
         :return:
             - thresholds: torch.tensor (batch_size, max-length-of-beam-seqs),
             - beam_seq_of_all_steps: [beam_seq(step=1), ..., beam_seq(step = max-length-of-beam-seqs)]
         """
-        # TODO: implementation of stochastic sequence sampling with "smoothing_window"
-
         # don't use dropouts during beam search
         self.decoder.eval()
 
@@ -599,10 +600,10 @@ class Model(nn.Module):
         device = encoder_output.device
         batch_size = src_mask.size(0)
 
-        # Recurrent models only: initialize RNN hidden state
-        # pylint: disable=protected-access
-        encoder_output = tile(encoder_output.contiguous(), beam_size, dim=0)  # (batch_size * beam_size, src_len, enc_hidden_size)
-        src_mask = tile(src_mask, beam_size, dim=0)  # (batch_size * beam_size, 1, src_len)
+        uniform_dist = Uniform(
+            low=torch.tensor([0.], device=device),
+            high=torch.tensor([1.], device=device),
+        )
 
         # Transformer only: create target mask
         trg_mask = src_mask.new_ones([1, 1, 1])  # transformer only
@@ -644,32 +645,33 @@ class Model(nn.Module):
                                    dtype=torch.bool,
                                    device=device)  # (batch_size, beam_size)
         step = 0
-        while not beam_finished.all():
+        while not beam_finished.all() and step < max_iteration:
             step += 1
 
             # This decides which part of the predicted sentence we feed to the decoder to make the next prediction.
             # For Transformer, we feed the complete predicted sentence so far.
             # For Recurrent models, only feed the previous target word prediction
-            decoder_input = beam_seq  # (batch_size * beam_size, step)
+            decoder_input = beam_seq  # (batch_size * (beam_size+a), step)
+            beam_size_ = int(beam_seq.shape[0] / batch_size) # = beam_size+a
 
             # expand current hypotheses
             # decode one single step
             # logits: scores before final softmax; (batch_size * beam_size + finished_batch_size, step, trg_vocab_size)
             logits, _, _, _ = self.decoder(
                 trg_embed=self.trg_embed(decoder_input),  # trg_embed = embed(decoder_input)
-                encoder_output=encoder_output,
-                src_mask=src_mask,
+                encoder_output=tile(encoder_output.contiguous(), beam_size_, dim=0),  # (batch_size * (beam_size+a), src_len, enc_hidden_size),
+                src_mask=tile(src_mask, beam_size_, dim=0),  # (batch_size * (beam_size+a), 1, src_len),
                 trg_mask=trg_mask,  # subsequent mask for Transformer only
-                finished=beam_finished.reshape(batch_size * beam_size).nonzero().squeeze(1),
+                finished=beam_finished.reshape(-1).nonzero().squeeze(1),
                 eos_index=self.eos_index,
             )
 
             # For the Transformer we made predictions for all time steps up to
             # this point, so we only want to know about the last time step.
-            logits = logits[:, -1] / temperature  # (batch_size * beam_size, trg_vocab_size)
+            logits = logits[:, -1] / temperature  # (batch_size * (beam_size+a), trg_vocab_size)
 
             # compute log probability over trg vocab given a previous sequence
-            log_probs = F.log_softmax(logits, dim=-1).squeeze(1)  # (batch_size * beam_size, trg_vocab_size)
+            log_probs = F.log_softmax(logits, dim=-1).squeeze(1)  # (batch_size * (beam_size+a), trg_vocab_size)
             beam_vocab_score = log_probs
 
             # compute length penalty
@@ -684,63 +686,98 @@ class Model(nn.Module):
 
             # correct `score_adjust_coeff` for  `beam_vocab_score`
             if beam_finished.any():
-                # `beam_finished` shape : (batch_size, beam_size)
+                # `beam_finished` shape : (batch_size, beam_size+a)
                 finished_ids = beam_finished.reshape(-1).nonzero().reshape(-1)
 
                 # correct `score_adjust_coeff` so that the scores of the finished sequences do not change
-                # `score_adjust_coeff` shape: (1) -> (batch_size * beam_size + finished_batch_size)
-                score_adjust_coeff *= torch.ones((batch_size * beam_size + finished_batch_size, 1), device=device)
+                # `score_adjust_coeff` shape: (1) -> (batch_size*(beam_size+a), 1)
+                score_adjust_coeff *= torch.ones((beam_finished.numel(), 1), device=device)
                 score_adjust_coeff[finished_ids] = 1.0
 
             # apply length penalty to `beam_vocab_score`
-            # 'beam_score': (batch_size, beam_size) -> (batch_size*beam_size, 1)
+            # 'beam_score': (batch_size, beam_size+a) -> (batch_size*(beam_size+a), 1)
             beam_score = beam_score.reshape(-1, 1)
-            # 'beam_vocab_score': (batch_size*beam_size, trg_vocab_size)
+            # 'beam_vocab_score': (batch_size*(beam_size+a), trg_vocab_size)
             beam_vocab_score = score_adjust_coeff * beam_score + 1 / length_penalty * beam_vocab_score
 
-            # flatten 'beam_vocab_score':  (batch_size*beam_size, trg_vocab_size) -> (batch_size, beam_size*trg_vocab_size)
-            beam_vocab_score = beam_vocab_score.reshape(batch_size, beam_size * trg_vocab_size)
+            # flatten 'beam_vocab_score':  (batch_size*(beam_size+a), trg_vocab_size) -> (batch_size, (beam_size+a)*trg_vocab_size)
+            beam_vocab_score = beam_vocab_score.reshape(batch_size, -1)
 
             # pick currently best top k hypotheses as beam set (flattened order)
-            # `aug_beam_score` and `aug_beam_ids` shape: (batch_size, beam_size+1)
-            # 'aug' is the abbreviation for 'augmented'.
-            aug_beam_score, aug_beam_index = beam_vocab_score.topk(beam_size + 1, dim=-1, sorted=True, largest=True)
+            if smoothing_factor == 0:
+                # `beam_score` and `beam_index` shape: (batch_size, beam_size)
+                beam_score, beam_index = beam_vocab_score.topk(beam_size, dim=-1, sorted=True, largest=True)
+                # calc threshold: (batch_size)
+                threshold = beam_score[:,-1]
+
+            else:  # stochastic sampling of hypothesis with score less than “threshold” but greater than "threshold - smoothing_factor"
+                # sort: (batch_size, (beam_size+a)*trg_vocab_size) -> (batch_size, (beam_size+a)*trg_vocab_size)
+                sorted_beam_vocab_score, sorted_beam_vocab_index = beam_vocab_score.sort(dim=1, descending=True)
+
+                # calc threshold: (batch_size)
+                threshold = sorted_beam_vocab_score[:, beam_size-1].detach().clone()
+
+                # score adjustment
+                sorted_beam_vocab_score += smoothing_factor - threshold.unsqueeze(-1)
+
+                # delete unnecessary columns
+                adoption_candidate_column = (sorted_beam_vocab_score >= 0).any(dim=0)
+                sorted_beam_vocab_score = sorted_beam_vocab_score[:, adoption_candidate_column]
+                sorted_beam_vocab_index = sorted_beam_vocab_index[:, adoption_candidate_column]
+
+                # adoption
+                noise = smoothing_factor * uniform_dist.sample([batch_size, sorted_beam_vocab_score.shape[1]]).squeeze(-1)
+                adoption_mask = sorted_beam_vocab_score - noise > 0
+                sorted_beam_vocab_score[~adoption_mask] = -np.inf
+
+                # delete unnecessary columns:  (batch_size, beam_size+a)
+                beam_score = sorted_beam_vocab_score[:, adoption_mask.any(dim=0)]
+                beam_index = sorted_beam_vocab_index[:, adoption_mask.any(dim=0)]
+                adoption_mask = adoption_mask[:, adoption_mask.any(dim=0)]
+
+                # restore adjusted score to original score
+                beam_score += - smoothing_factor + threshold.unsqueeze(-1)
 
             # reconstruct beam origin and true word ids from flattened order
-            beam_origin_index = aug_beam_index.floor_divide(trg_vocab_size)  # (batch_size, beam_size+1)
-            word_index = aug_beam_index.fmod(trg_vocab_size)  # (batch_size, beam_size+1)
+            beam_origin_index = beam_index.floor_divide(trg_vocab_size)  # (batch_size, beam_size)
+            word_index = beam_index.fmod(trg_vocab_size)  # (batch_size, beam_size)
 
-            # compute `arg_beam_finished`; (batch_size, beam_size+1)
-            aug_beam_finished = word_index.eq(eos_index) | aug_beam_score.eq(-np.inf)
+            # compute `arg_beam_finished`; (batch_size, beam_size)
+            beam_finished = word_index.eq(eos_index) | beam_score.eq(-np.inf)
 
             # map beam_index to selected_index in the flat representation
             select_index = (
-                beam_origin_index  # (batch_size, beam_size+1)
+                beam_origin_index  # (batch_size, beam_size+a)
                 + beam_offset.unsqueeze(1)  # (batch_size, 1)
-            )  # (batch_size, beam_size)
-            select_index = select_index.view(-1)  # (batch_size * (beam_size+1))
+            )  # (batch_size, beam_size+a)
+            select_index = select_index.view(-1)  # (batch_size * (beam_size+a))
 
             # append the latest prediction
-            aug_beam_seq = torch.cat([
-                beam_seq.index_select(0, select_index),  # (batch_size * (beam_size+1), step)
-                word_index.view(-1, 1)  # (batch_size * (beam_size+1), 1)
-            ], -1).reshape(batch_size, beam_size + 1, step + 1)  # (batch_size, beam_size+1, step+1)
+            beam_seq = torch.cat([
+                beam_seq.index_select(0, select_index),  # (batch_size * (beam_size+a), step)
+                word_index.view(-1, 1)  # (batch_size * (beam_size+a), 1)
+            ], -1)  # (batch_size*(beam_size+1), step+1)
 
-            # separate results into 'beam_*' and 'runnerup_*'
-            beam_seq_old = beam_seq  # this will be used in the process "calc thresholds"
-            beam_score = aug_beam_score[:, :beam_size]  # (batch_size, beam_size)
-            beam_finished = aug_beam_finished[:, :beam_size]  # (batch_size, beam_size)
-            beam_seq = aug_beam_seq[:, :beam_size, :]  # (batch_size, beam_size, step+1)
-            runnerup_score = aug_beam_score[:, -1]  # (batch_size)
+            # create a list-type variable of 'beam_seq' for output
+            if smoothing_factor == 0:
+                beam_seq_list = [beam_seq.reshape(batch_size,beam_size,step+1)[i] for i in range(batch_size)]
+            else:
+                beam_seq_list = [beam_seq.reshape(batch_size,-1,step+1)[i][adoption_mask[i]] for i in range(batch_size)]
 
-            # backup beam_seq
-            beam_seq_of_all_steps.append(beam_seq)
+                # update beam_offset
+                beam_offset = torch.arange(0, select_index.shape[0],
+                                           step=select_index.shape[0]/batch_size,
+                                           dtype=torch.long,
+                                           device=device)
 
-            # reshape `beam_seq` to its original size
-            beam_seq = beam_seq.reshape(batch_size * beam_size, step + 1)  # (batch_size*beam_size, hyp_len)
+                # rewrite sequences that was not adopted into dummy eos sequences
+                beam_seq[~adoption_mask.view(-1)] = eos_index
 
-            # calc thresholds
-            thresholds.append(beam_score[:,-1])
+            # store threshold
+            thresholds.append(threshold)
+
+            # backup beam_seq_list
+            beam_seq_of_all_steps.append(beam_seq_list)
 
             # update previous length penalty with current one
             length_penalty_prev = length_penalty
@@ -769,7 +806,7 @@ class Model(nn.Module):
         :param n_best: return this many hypotheses, <= beam
         :return:
             - thresholds: torch.tensor (max_output_length),
-            - beam_seq_of_all_steps: [beam_seq(step=0), ..., beam_seq(step=max_output_length-1)]
+            - beam_seq_of_all_steps: [beam_seq_list(step=0), ..., beam_seq_list(step=max_output_length-1)]
         """
         # don't use dropouts during beam search
         self.decoder.eval()

--- a/joeynmt/model.py
+++ b/joeynmt/model.py
@@ -750,9 +750,6 @@ class Model(nn.Module):
                 adoption_prob = adoption_prob[:, adoption_column]
                 adoption_mask = adoption_mask[:, adoption_column]
 
-                # restore adjusted score to original score
-                beam_score += - smoothing_factor + threshold.unsqueeze(-1)
-
             # reconstruct beam origin and true word ids from flattened order
             beam_origin_index = beam_index.floor_divide(trg_vocab_size)  # (batch_size, beam_size)
             word_index = beam_index.fmod(trg_vocab_size)  # (batch_size, beam_size)

--- a/joeynmt/model.py
+++ b/joeynmt/model.py
@@ -571,7 +571,8 @@ class Model(nn.Module):
 
     def _compute_threshold_by_vanilla_beam_search(self, beam_size: int,
                                                   encoder_output: Tensor, encoder_hidden: Tensor, src_mask: Tensor,
-                                                  temperature: float, alpha: float = 1.0) -> (np.array, np.array):
+                                                  temperature: float, alpha: float = 1.0,
+                                                  smoothing_window: float = 0.0) -> (np.array, np.array):
         """
         Compute thresholds for soft beam policy based on vanilla_beam_search with size k.
 
@@ -581,10 +582,13 @@ class Model(nn.Module):
         :param src_mask:
         :param temperature: softmax temperature
         :param alpha: `alpha` factor for length penalty
+        :param smoothing_window: smoothing window for stochastic sampling
         :return:
             - thresholds: torch.tensor (batch_size, max-length-of-beam-seqs),
             - beam_seq_of_all_steps: [beam_seq(step=1), ..., beam_seq(step = max-length-of-beam-seqs)]
         """
+        # TODO: implementation of stochastic sequence sampling with "smoothing_window"
+
         # don't use dropouts during beam search
         self.decoder.eval()
 


### PR DESCRIPTION
- 収束性保証のために、閾値未満の系列を確率的に採用するようにした
- バッチindexによって、閾値の系列長や、各ステップでの採択系列数などが異なる
- 出力を以下のように変更した
  -  tensor形式でなく、list形式。listの要素数はどの変数も`batch_size`
  - `threshold_of_all_steps`も`beam_seq_of_all_steps`も`step=1`からの情報を保持（従来は`step=0`からだった）
  - 各`beam_seq`の採択確率を`beam_prob_of_each_all_steps`で出力（これまでは決定的な手法だったので常に1だったけど今は違うので）
  