### PR TITLE
ベースラインとしてのBLEU値の平均値をサンプルごとに取得するようにする

### DIFF
--- a/configs/sbp_cross_domain.yaml
+++ b/configs/sbp_cross_domain.yaml
@@ -56,7 +56,7 @@ training:
     hyperparameters:
       temperature: 1
       alpha: 1
-      reward: "bleu"
+      reward: "bleu_sbp"
       samples: 5
       max_adoption_size: 100
       baseline: "average_reward_baseline"

--- a/configs/sbp_in_domain.yaml
+++ b/configs/sbp_in_domain.yaml
@@ -56,7 +56,7 @@ training:
     hyperparameters:
       temperature: 1
       alpha: 1
-      reward: "bleu"
+      reward: "bleu_sbp"
       samples: 5
       max_adoption_size: 100
       baseline: "average_reward_baseline"


### PR DESCRIPTION
これまでロスを計算する際のベースラインとして学習中のBLEU値全ての平均値が用いられていたが、これをサンプルワイズに計算するような設定（ `bleu_sbp` ）を追加しました。